### PR TITLE
CMT-8480: Add cloud-identity.policies.readonly scope to base scopes

### DIFF
--- a/Migrate/PowerShell/GCP_Configuration.ps1
+++ b/Migrate/PowerShell/GCP_Configuration.ps1
@@ -157,7 +157,8 @@ Function Build-Scopes-List([string]$Scope = "Standard")
     "https://www.googleapis.com/auth/user.phonenumbers.read",
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",
-    "https://www.googleapis.com/auth/forms"
+    "https://www.googleapis.com/auth/forms",
+    "https://www.googleapis.com/auth/cloud-identity.policies.readonly"
     )
 
     $SourceLimitedScopes = @(


### PR DESCRIPTION
This pull request adds a new Google API scope to the list of available scopes in the `Build-Scopes-List` function in `GCP_Configuration.ps1`. This change allows for read-only access to Cloud Identity policies.

Authentication scope updates:

* Added `"https://www.googleapis.com/auth/cloud-identity.policies.readonly"` to the `$SourceScopes` array in the `Build-Scopes-List` function to enable read-only access to Cloud Identity policies.